### PR TITLE
Issue#2698 persist column visibility state stage 3 completes issue

### DIFF
--- a/app/controllers/preference_sets_controller.rb
+++ b/app/controllers/preference_sets_controller.rb
@@ -1,0 +1,25 @@
+class PreferenceSetsController < ApplicationController
+  before_action :skip_authorization, :set_table_name
+  def table_state
+    render json: PreferenceSetTableStateService.new(user_id: current_user.id).table_state(
+      table_name: @table_name
+    )
+  end
+
+  def table_state_update
+      render json: PreferenceSetTableStateService.new(user_id: current_user.id).update!(
+        table_state: params["table_state"],
+        table_name: @table_name
+      )
+
+    rescue PreferenceSetTableStateService::TableStateUpdateFailed
+      render json: {error: "Failed to update table state for '#{@table_name}'" } 
+  end
+
+
+  private 
+  def set_table_name
+    @table_name = params[:table_name]
+  end
+end
+

--- a/app/decorators/preference_set_decorator.rb
+++ b/app/decorators/preference_set_decorator.rb
@@ -1,0 +1,13 @@
+class PreferenceSetDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/helpers/preference_sets_helper.rb
+++ b/app/helpers/preference_sets_helper.rb
@@ -1,0 +1,2 @@
+module PreferenceSetsHelper
+end

--- a/app/javascript/src/dashboard.js
+++ b/app/javascript/src/dashboard.js
@@ -90,9 +90,42 @@ $('document').ready(() => {
   const casaCasePath = id => `/casa_cases/${id}`
   const volunteersTable = $('table#volunteers').DataTable({
     autoWidth: false,
-    stateSave: false,
+    stateSave: true,
+    initComplete: function(settings, json) {
+      this.api().columns().every(function(index) {
+        var columnVisible = this.visible();
+        $('#visibleColumns input[data-column="' + index + '"]').prop('checked', columnVisible);
+      });
+    },
+    stateSaveCallback: function (settings, data) {
+      $.ajax({
+        url: "/preference_sets/table_state_update/" + settings.nTable.id + '_table',
+
+        data: {
+          table_state: JSON.stringify(data),
+        },
+        dataType: "json",
+        type: "POST",
+        success: function (response) { console.log( 'from stateSaveCallback', data) }
+      });
+     
+    },
+    stateSaveParams: function(settings, data) {
+      data.search.search = '';
+      return data;
+    },
+    stateLoadCallback: function (settings, callback) {
+      $.ajax({ 
+        url: '/preference_sets/table_state/' + settings.nTable.id + '_table',
+        dataType: 'json',
+        type: 'GET',
+        success: function(json) {
+          callback(json);
+        }
+      });
+    },
     order: [[6, 'desc']],
-    columns: [
+    columns: [ 
       {
         name: 'display_name',
         render: (data, type, row, meta) => {
@@ -107,7 +140,6 @@ $('document').ready(() => {
       {
         name: 'email',
         render: (data, type, row, meta) => row.email,
-        visible: false
       },
       {
         className: 'supervisor-column',
@@ -171,7 +203,6 @@ $('document').ready(() => {
             : 'None ❌'
         },
         searchable: false,
-        visible: true
       },
       {
         name: 'contacts_made_in_past_days',
@@ -182,7 +213,6 @@ $('document').ready(() => {
           `
         },
         searchable: false,
-        visible: false
       },
       {
         name: 'hours_spent_in_days',
@@ -201,19 +231,18 @@ $('document').ready(() => {
           return row.extra_languages.length > 0 ? `<span class="language-icon" data-toggle="tooltip" title="${languages}">🌎</span>` : ''
         },
         searchable: false,
-        visible: true
       },
       {
         name: 'actions',
         orderable: false,
         render: (data, type, row, meta) => {
           return `
-            <span class="mobile-label">Actions</span>
-            <a href="${editVolunteerPath(row.id)}" class="main-btn primary-btn btn-hover btn-sm">
-              <i class="lni lni-pencil-alt mr-5"></i> Edit
+          <span class="mobile-label">Actions</span>
+            <a href="${editVolunteerPath(row.id)}" class="btn btn-primary">
+              Edit
             </a>
-            <a href="${impersonateVolunteerPath(row.id)}" class="main-btn dark-btn btn-hover btn-sm">
-              <i class="lni lni-user mr-5"></i> Impersonate
+            <a href="${impersonateVolunteerPath(row.id)}" class="btn btn-secondary">
+              Impersonate
             </a>
           `
         },
@@ -258,15 +287,9 @@ $('document').ready(() => {
   // columns are visible
   volunteersTable.columns().every(function (index) {
     const columnVisible = this.visible()
-
-    if (columnVisible) {
-      $('#visibleColumns input[data-column="' + index + '"]').prop('checked', true)
-    } else {
-      $('#visibleColumns input[data-column="' + index + '"]').prop('checked', false)
-    }
-
+    $('#visibleColumns input[data-column="' + index + '"]').prop('checked', columnVisible);
     return true
-  })
+  }) 
 
   const casaCasesTable = $('table#casa-cases').DataTable({
     autoWidth: false,

--- a/app/services/preference_set_table_state_service.rb
+++ b/app/services/preference_set_table_state_service.rb
@@ -1,0 +1,25 @@
+class PreferenceSetTableStateService
+  class TableStateUpdateFailed < StandardError; end
+  def initialize(user_id:)
+    @user_id = user_id
+  end
+
+  def table_state(table_name:)
+    preference_set.table_state[table_name]
+  end
+
+  def update!(table_name:, table_state:)
+    preference_set.table_state[table_name] = table_state
+    preference_set.save!
+
+      rescue StandardError
+        raise TableStateUpdateFailed, "Failed to update table state for '#{table_name}'"
+  end
+
+private
+  attr_reader :user_id
+  def preference_set
+    @preference_set ||= PreferenceSet.find_by!(user_id: user_id)
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,13 @@ Rails.application.routes.draw do
   devise_for :all_casa_admins, path: "all_casa_admins", controllers: {sessions: "all_casa_admins/sessions"}
   devise_for :users, controllers: {sessions: "users/sessions", passwords: "users/passwords"}
 
+  resources :preference_sets, only: [] do
+    collection do
+      post "/table_state_update/:table_name", to: "preference_sets#table_state_update", as: :table_state_update
+      get "/table_state/:table_name", to: "preference_sets#table_state", as: :table_state
+    end
+  end
+  
   concern :with_datatable do
     post "datatable", on: :collection
   end

--- a/spec/decorators/preference_set_decorator_spec.rb
+++ b/spec/decorators/preference_set_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe PreferenceSetDecorator do
+end

--- a/spec/helpers/preference_sets_helper_spec.rb
+++ b/spec/helpers/preference_sets_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PreferenceSetsHelper. For example:
+#
+# describe PreferenceSetsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PreferenceSetsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/preference_sets_spec.rb
+++ b/spec/requests/preference_sets_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "PreferenceSets", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/services/preference_set_table_state_service_spec.rb
+++ b/spec/services/preference_set_table_state_service_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe PreferenceSetTableStateService do
+  subject { described_class.new(user_id: user.id) }
+  
+  let!(:user) { create(:user) }
+  let(:preference_set) { user.preference_set }
+  let!(:table_state) { { "volunteers_table" => { "columns" => [{"visible" => true}] }} }
+  let(:table_state2) { { "columns" => [{"visible" => false}] }}
+  let(:table_name) { "volunteers_table" }
+
+  describe '#update!' do
+    context 'when the update is successful' do
+      it 'updates the table state' do
+        expect {
+          subject.update!(table_state: table_state2, table_name: table_name)
+        }.to change {
+          preference_set.reload.table_state
+        }.from({}).to({ table_name => table_state2 })
+      end
+    end
+
+    context 'when the update fails' do
+      before do
+        allow_any_instance_of(PreferenceSet).to receive(:save!).and_raise(ActiveRecord::RecordNotSaved)
+      end
+      
+      it 'raises an error' do
+        expect {
+          subject.update!(table_state: table_state2, table_name: table_name)
+        }.to raise_error(PreferenceSetTableStateService::TableStateUpdateFailed, "Failed to update table state for '#{table_name}'")
+      end
+    end
+  end
+
+  describe '#table_state' do
+    context 'when the preference set exists' do
+      before do
+        table_state = { "columns" => [{"visible" => true}]}
+        user.preference_set.table_state["volunteers_table"] = table_state
+        user.preference_set.save! 
+      end
+
+      it 'returns the table state' do
+        binding.pry
+        expect(subject.table_state(table_name: "volunteers_table")).to eq(table_state["volunteers_table"])
+      end
+    end
+
+    context 'when there is no data for that table name' do
+      before do
+        preference_set.table_state = {}
+        preference_set.save
+      end
+
+      it 'returns nil' do
+        expect(subject.table_state(table_name: table_name)).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### What github issue is this PR for, if any?
(3/3) #2 

### What changed, and why?
It adds preference_sets controller with two new actions that will load and update the table_state from preference_sets table. I also adds a service object that will hundle table_state. 

### How will this affect user permissions?
- Volunteer permissions:
- Supervisor permissions:
- Admin permissions:

### How is this tested? (please write tests!) 💖💪
A service test has been added to test this new class. In it I cover 4 cases: 
table_state 
--when proference_set exist: return the data
--when there's not data: return nil

update
--when the update is successful: updates the table state
--when the update fails: it should raise and error 

### Screenshots please :)


### Feelings gif (optional)
What gif best describes your feeling working on this issue? https://giphy.com/
How to embed:
`![alt text](https://media.giphy.com/media/1nP7ThJFes5pgXKUNf/giphy.gif)`

### Feedback please? (optional)
We are very interested in your feedback! Please give us some :) https://forms.gle/1D5ACNgTs2u9gSdh9
